### PR TITLE
fix: address clippy warnings in github.rs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,32 +1,30 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
-    hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-merge-conflict
-      - id: check-yaml
-      - id: check-toml
-      - id: mixed-line-ending
-        args: [--fix=lf]
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.6.0
+      hooks:
+          - id: trailing-whitespace
+          - id: end-of-file-fixer
+          - id: check-merge-conflict
+          - id: check-yaml
+          - id: check-toml
+          - id: mixed-line-ending
+            args: [--fix=lf]
 
-  - repo: local
-    hooks:
-      - id: cargo-fmt
-        name: cargo fmt
-        entry: cargo fmt --all
-        language: system
-        pass_filenames: false
-        types: [rust]
-      - id: cargo-clippy
-        name: cargo clippy
-        entry: cargo clippy --all-targets --all-features -- -D warnings
-        language: system
-        pass_filenames: false
-        stages: [pre-push]
-      - id: cargo-test
-        name: cargo test
-        entry: cargo test --all-features
-        language: system
-        pass_filenames: false
-        stages: [pre-push]
+    - repo: local
+      hooks:
+          - id: cargo-fmt
+            name: cargo fmt
+            entry: cargo fmt --all
+            language: system
+            pass_filenames: false
+          - id: cargo-clippy
+            name: cargo clippy
+            entry: cargo clippy --all-targets --all-features -- -D warnings
+            language: system
+            pass_filenames: false
+          - id: cargo-test
+            name: cargo test
+            entry: cargo test --all-features
+            language: system
+            pass_filenames: false
+            stages: [pre-push]

--- a/src/registry/github.rs
+++ b/src/registry/github.rs
@@ -56,14 +56,14 @@ impl RateLimitInfo {
 
     /// Compute the duration to wait until the rate limit resets
     fn wait_duration(&self) -> Option<Duration> {
-        self.reset.and_then(|reset_ts| {
+        self.reset.map(|reset_ts| {
             let now = chrono::Utc::now().timestamp();
             let wait = reset_ts - now;
             if wait > 0 {
-                Some(Duration::from_secs(wait as u64))
+                Duration::from_secs(wait as u64)
             } else {
                 // Reset time already passed, retry immediately
-                Some(Duration::from_secs(1))
+                Duration::from_secs(1)
             }
         })
     }
@@ -145,7 +145,7 @@ where
                     }
                     let wait = retry_after_from_response(&resp, attempt);
                     let wait_secs = wait.as_secs();
-                    print_rate_limit_wait(&format!("Rate limited (429)."), wait_secs, attempt);
+                    print_rate_limit_wait("Rate limited (429).", wait_secs, attempt);
                     std::thread::sleep(wait);
                     continue;
                 }
@@ -169,7 +169,7 @@ where
                                     MAX_RATE_LIMIT_WAIT_SECS
                                 );
                             }
-                            print_rate_limit_wait(&format!("Rate limit exceeded (403)."), wait.as_secs(), attempt);
+                            print_rate_limit_wait("Rate limit exceeded (403).", wait.as_secs(), attempt);
                             std::thread::sleep(wait);
                             continue;
                         }


### PR DESCRIPTION
- Use map instead of and_then with Some for Option transformation
- Remove unnecessary format! calls for static strings