### PR TITLE
feat: install-all installs from all added taps (#24)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ skillshub install <owner/repo/skill>[@commit]  # Install a skill
 skillshub uninstall <owner/repo/skill>      # Remove installed skill
 skillshub update [owner/repo/skill]         # Update skill(s) to latest
 skillshub info <owner/repo/skill>           # Show skill details
-skillshub install-all                       # Install all from default tap
+skillshub install-all                       # Install all from all added taps
 ```
 
 ### Tap Management

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Install all skills from default taps
+    /// Install all skills from all added taps
     InstallAll,
 
     /// Install a skill (format: owner/repo/skill[@commit])

--- a/src/registry/skill.rs
+++ b/src/registry/skill.rs
@@ -671,26 +671,21 @@ pub fn show_skill_info(full_name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Install all skills from default taps
+/// Install all skills from all added taps
 pub fn install_all() -> Result<()> {
     let db = db::init_db()?;
 
-    let mut default_taps: Vec<String> = db
-        .taps
-        .iter()
-        .filter(|(_, tap)| tap.is_default)
-        .map(|(name, _)| name.clone())
-        .collect();
-    default_taps.sort();
+    let mut all_taps: Vec<String> = db.taps.keys().cloned().collect();
+    all_taps.sort();
 
-    if default_taps.is_empty() {
-        println!("No default taps configured.");
+    if all_taps.is_empty() {
+        println!("No taps configured. Add one with 'skillshub tap add <url>'.");
         return Ok(());
     }
 
     let mut installed_count = 0;
 
-    for tap_name in default_taps {
+    for tap_name in all_taps {
         installed_count += install_all_from_tap_internal(&db, &tap_name)?;
     }
 


### PR DESCRIPTION
  Previously `skillshub install-all` only installed skills from default
  taps. Now it installs from all added taps, so users with multiple taps
  don't need to run `tap install-all` for each one individually