### PR TITLE
fix: panic on multi-byte UTF-8 in truncate_string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "skillshub"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillshub"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.74.0"
 description = "A package manager for AI coding agent skills - like homebrew for skills"

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,8 +62,7 @@ mod tests {
         let chinese = "基於 Manus 風格的檔案規劃系統";
         let result = truncate_string(chinese, 20);
         assert!(result.ends_with("..."));
-        // Verify the result is valid UTF-8 (implicit—Rust strings are always valid)
-        assert!(result.len() <= 23); // up to 20 bytes of chars + "..."
+        assert!(result.len() <= 20); // up to 17 bytes of chars + "..."
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,16 @@ pub fn truncate_string(value: &str, max_len: usize) -> String {
     if value.len() <= max_len {
         value.to_string()
     } else {
-        format!("{}...", &value[..max_len.saturating_sub(3)])
+        let truncate_at = max_len.saturating_sub(3);
+        // Find the last char boundary at or before truncate_at to avoid
+        // slicing in the middle of a multi-byte UTF-8 character.
+        let end = value
+            .char_indices()
+            .map(|(i, _)| i)
+            .take_while(|&i| i <= truncate_at)
+            .last()
+            .unwrap_or(0);
+        format!("{}...", &value[..end])
     }
 }
 
@@ -45,6 +54,16 @@ mod tests {
     fn test_truncate_string() {
         assert_eq!(truncate_string("short", 10), "short");
         assert_eq!(truncate_string("hello world", 8), "hello...");
+    }
+
+    #[test]
+    fn test_truncate_string_multibyte() {
+        // Should not panic when truncation falls inside a multi-byte char
+        let chinese = "基於 Manus 風格的檔案規劃系統";
+        let result = truncate_string(chinese, 20);
+        assert!(result.ends_with("..."));
+        // Verify the result is valid UTF-8 (implicit—Rust strings are always valid)
+        assert!(result.len() <= 23); // up to 20 bytes of chars + "..."
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `truncate_string` sliced at raw byte offsets, panicking when the cut falls inside a multi-byte UTF-8 character (e.g. Chinese skill descriptions like `planning-with-files-zht`)
- Use `char_indices()` to find a valid char boundary before slicing
- Add test covering multi-byte truncation
- Bump version to 1.0.1

## Test plan
- [x] `cargo test util::tests` — all 6 pass including new `test_truncate_string_multibyte`
- [x] Full `cargo test` — all 189 tests pass