### PR TITLE
feat: add Kiro CLI and 6 trending agent support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "skillshub"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillshub"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 rust-version = "1.74.0"
 description = "A package manager for AI coding agent skills - like homebrew for skills"

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Skillshub automatically detects and links to these coding agents:
 | Kimi     | `~/.kimi`      | `~/.kimi/skills`      |
 | OpenClaw | `~/.openclaw`  | `~/.openclaw/skills`  |
 | ZeroClaw | `~/.zeroclaw`  | `~/.zeroclaw/skills`  |
+| Kiro     | `~/.kiro`      | `~/.kiro/steering`    |
 
 ## GitHub API & Authentication
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ Skillshub automatically detects and links to these coding agents:
 | OpenClaw | `~/.openclaw`  | `~/.openclaw/skills`  |
 | ZeroClaw | `~/.zeroclaw`  | `~/.zeroclaw/skills`  |
 | Kiro     | `~/.kiro`      | `~/.kiro/steering`    |
+| Gemini   | `~/.gemini`    | `~/.gemini/skills`    |
+| Copilot  | `~/.copilot`   | `~/.copilot/skills`   |
+| Junie    | `~/.junie`     | `~/.junie/skills`     |
+| Augment  | `~/.augment`   | `~/.augment/skills`   |
+| Warp     | `~/.warp`      | `~/.warp/skills`      |
+| Cline    | `~/.cline`     | `~/.cline/skills`     |
 
 ## GitHub API & Authentication
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,6 +100,12 @@ Local directory layout:
 | OpenClaw | `~/.openclaw`  | `~/.openclaw/skills`  |
 | ZeroClaw | `~/.zeroclaw`  | `~/.zeroclaw/skills`  |
 | Kiro     | `~/.kiro`      | `~/.kiro/steering`    |
+| Gemini   | `~/.gemini`    | `~/.gemini/skills`    |
+| Copilot  | `~/.copilot`   | `~/.copilot/skills`   |
+| Junie    | `~/.junie`     | `~/.junie/skills`     |
+| Augment  | `~/.augment`   | `~/.augment/skills`   |
+| Warp     | `~/.warp`      | `~/.warp/skills`      |
+| Cline    | `~/.cline`     | `~/.cline/skills`     |
 
 To add a new agent, update `KNOWN_AGENTS` in `src/agent.rs`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,6 +99,7 @@ Local directory layout:
 | Kimi     | `~/.kimi`      | `~/.kimi/skills`      |
 | OpenClaw | `~/.openclaw`  | `~/.openclaw/skills`  |
 | ZeroClaw | `~/.zeroclaw`  | `~/.zeroclaw/skills`  |
+| Kiro     | `~/.kiro`      | `~/.kiro/steering`    |
 
 To add a new agent, update `KNOWN_AGENTS` in `src/agent.rs`.
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -16,6 +16,12 @@ pub const KNOWN_AGENTS: &[(&str, &str)] = &[
     (".openclaw", "skills"),
     (".zeroclaw", "skills"),
     (".kiro", "steering"),
+    (".gemini", "skills"),
+    (".copilot", "skills"),
+    (".junie", "skills"),
+    (".augment", "skills"),
+    (".warp", "skills"),
+    (".cline", "skills"),
 ];
 
 /// Discovered agent info
@@ -88,6 +94,12 @@ mod tests {
         assert!(names.contains(".openclaw"));
         assert!(names.contains(".zeroclaw"));
         assert!(names.contains(".kiro"));
+        assert!(names.contains(".gemini"));
+        assert!(names.contains(".copilot"));
+        assert!(names.contains(".junie"));
+        assert!(names.contains(".augment"));
+        assert!(names.contains(".warp"));
+        assert!(names.contains(".cline"));
     }
 
     #[test]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -15,6 +15,7 @@ pub const KNOWN_AGENTS: &[(&str, &str)] = &[
     (".kimi", "skills"),
     (".openclaw", "skills"),
     (".zeroclaw", "skills"),
+    (".kiro", "steering"),
 ];
 
 /// Discovered agent info
@@ -86,6 +87,7 @@ mod tests {
         assert!(names.contains(".kimi"));
         assert!(names.contains(".openclaw"));
         assert!(names.contains(".zeroclaw"));
+        assert!(names.contains(".kiro"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Kiro CLI support with `~/.kiro/steering` as its native instruction directory
- Add 6 trending coding agents: Gemini CLI, GitHub Copilot, JetBrains Junie, Augment Code, Warp, and Cline
- Bump version to 1.0.3

Skillshub now supports **17 agents** total.

## New agents

| Agent | Directory | Skills Path |
|-------|-----------|-------------|
| Kiro | `~/.kiro` | `~/.kiro/steering` |
| Gemini | `~/.gemini` | `~/.gemini/skills` |
| Copilot | `~/.copilot` | `~/.copilot/skills` |
| Junie | `~/.junie` | `~/.junie/skills` |
| Augment | `~/.augment` | `~/.augment/skills` |
| Warp | `~/.warp` | `~/.warp/skills` |
| Cline | `~/.cline` | `~/.cline/skills` |

## Test plan
- [x] `cargo test` — 277/277 pass
- [x] `cargo build` — compiles cleanly
- [x] `cargo run -- agents` — verify new agents appear when their directories exist
- [x] `cargo run -- link` — verify skills link to new agent directories